### PR TITLE
Fix images URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
   ],
   "author": "Eric Chang",
   "license": {
-  	"type": "MIT",
-  	"url": "https://github.com/myspace/page-previewer/blob/master/LICENSE"
+    "type": "MIT",
+    "url": "https://github.com/myspace/page-previewer/blob/master/LICENSE"
   },
   "peerDependencies": {
     "react-native": "^0.22.2"
   },
-  "repository" : "git://github.com/changey/react-native-page-previewer.git",
+  "repository": "git://github.com/changey/react-native-page-previewer.git",
   "dependencies": {
-    "cheerio-without-node-native": "^0.20.1"
+    "cheerio-without-node-native": "^0.20.1",
+    "url": "0.11.0"
   }
 }


### PR DESCRIPTION
@changey First, thanks for your work.

This pull request fixes the `images` property by returning valid image URLs by (1) adding `url@0.11.0` as a dependency for URL resolution and (2) reverting the changes in 56dbaaf.  In other words, it's going to use `myspace/page-previewer`'s original code for fetching images.

This works because some websites use an external website in its `<meta property="og:image">`.  So simply appending the image URL to its base URL won't work as you'll get results like: `http://example-website-to-previewhttp://the-path-to-the-image.com/image.jpg`.  So, instead, using a URL resolution utility to check for things like that solves that problem.

As a result, this should fix issue #1 